### PR TITLE
Add Expo support for mobile testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,40 @@ To run the unit tests for the components, use the following command:
 npm test
 ```
 
+## Running the App on a Mobile Device
+
+To run the app on a mobile device using Expo, follow these steps:
+
+1. Install the Expo CLI:
+   ```
+   npm install -g expo-cli
+   ```
+2. Start the Expo development server:
+   ```
+   expo start
+   ```
+3. Download the Expo Go app on your mobile device from the App Store (iOS) or Google Play Store (Android).
+4. Open the Expo Go app and scan the QR code displayed in the terminal or on the Expo development server page.
+
+## Building the App for Android and iOS
+
+To build the app for Android and iOS, follow these steps:
+
+1. Install the Expo CLI if you haven't already:
+   ```
+   npm install -g expo-cli
+   ```
+2. Build the app for Android:
+   ```
+   expo build:android
+   ```
+3. Build the app for iOS:
+   ```
+   expo build:ios
+   ```
+
+Follow the instructions provided by Expo to complete the build process and obtain the APK (Android) or IPA (iOS) files.
+
 ## Contributing Guidelines
 
 We welcome contributions to improve the app. Please follow these guidelines when contributing:

--- a/app.json
+++ b/app.json
@@ -1,0 +1,32 @@
+{
+  "expo": {
+    "name": "Book Tracking App",
+    "slug": "book-tracking-app",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    },
+    "updates": {
+      "fallbackToCacheTimeout": 0
+    },
+    "assetBundlePatterns": [
+      "**/*"
+    ],
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "adaptiveIcon": {
+        "foregroundImage": "./assets/adaptive-icon.png",
+        "backgroundColor": "#FFFFFF"
+      }
+    },
+    "web": {
+      "favicon": "./assets/favicon.png"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "book-tracking-app",
+  "version": "1.0.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web",
+    "build:android": "expo build:android",
+    "build:ios": "expo build:ios"
+  },
+  "dependencies": {
+    "expo": "^40.0.0",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
+    "react-native": "0.63.4",
+    "react-native-web": "^0.13.12",
+    "@react-navigation/native": "^5.8.10",
+    "@react-navigation/stack": "^5.12.8",
+    "react-native-gesture-handler": "^1.9.0",
+    "react-native-reanimated": "^1.13.2",
+    "react-native-safe-area-context": "^3.1.9",
+    "react-native-screens": "^2.15.2",
+    "react-native-walkthrough-tooltip": "^1.1.8",
+    "react-native-progress": "^4.1.2",
+    "react-native-camera": "^3.42.2",
+    "expo-status-bar": "~1.0.3",
+    "expo-app-loading": "^1.0.3"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.12.9"
+  },
+  "private": true
+}

--- a/src/App.js
+++ b/src/App.js
@@ -7,13 +7,26 @@ import AddBook from './components/AddBook';
 import EditBook from './components/EditBook';
 import ReadingGoals from './components/ReadingGoals';
 import { StyleSheet, View, Switch, Text } from 'react-native';
+import AppLoading from 'expo-app-loading';
+import { StatusBar } from 'expo-status-bar';
 
 const Stack = createStackNavigator();
 
 function App() {
   const [isDarkMode, setIsDarkMode] = useState(false);
+  const [isReady, setIsReady] = useState(false);
 
   const toggleSwitch = () => setIsDarkMode(previousState => !previousState);
+
+  if (!isReady) {
+    return (
+      <AppLoading
+        startAsync={loadResourcesAsync}
+        onFinish={() => setIsReady(true)}
+        onError={handleLoadingError}
+      />
+    );
+  }
 
   return (
     <NavigationContainer>
@@ -36,6 +49,7 @@ function App() {
           <Stack.Screen name="ReadingGoals" component={ReadingGoals} />
         </Stack.Navigator>
       </View>
+      <StatusBar style="auto" />
     </NavigationContainer>
   );
 }
@@ -68,5 +82,14 @@ const styles = StyleSheet.create({
     color: '#fff',
   },
 });
+
+async function loadResourcesAsync() {
+  // Load any resources or data that we need prior to rendering the app
+}
+
+function handleLoadingError(error) {
+  // Handle the loading error
+  console.warn(error);
+}
 
 export default App;


### PR DESCRIPTION
Add instructions for running and building the app on a mobile device using Expo.

* **README.md**
  - Add instructions for running the app on a mobile device using Expo.
  - Add instructions for building the app for Android and iOS.

* **app.json**
  - Add Expo configuration file with necessary settings for the app.

* **package.json**
  - Add scripts for building the app for Android and iOS.

* **src/App.js**
  - Import and use `AppLoading` from `expo` to handle app loading.
  - Add `expo-status-bar` to handle the status bar.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shnz99/book-tracking-app/pull/3?shareId=f9a0bdba-b53d-4cd7-a210-41a10a3d5de2).