### PR TITLE
Fix Jest configuration for React Native

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  presets: [
+    '@babel/preset-env',
+    '@babel/preset-react',
+    '@babel/preset-typescript',
+    '@babel/preset-react-native',
+  ],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  transform: {
+    '^.+\\.[t|j]sx?$': 'babel-jest',
+  },
+  transformIgnorePatterns: [
+    '/node_modules/',
+  ],
+  moduleNameMapper: {
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)$': '<rootDir>/__mocks__/fileMock.js',
+    '\\.(css|less)$': '<rootDir>/__mocks__/styleMock.js',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "@babel/plugin-transform-optional-chaining": "^7.25.9",
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-react": "^7.26.3",
+    "@babel/preset-typescript": "^7.26.0",
+    "@babel/preset-react-native": "^7.26.0",
     "@testing-library/react-native": "^13.0.0",
     "babel-loader": "^9.2.1",
     "clean-webpack-plugin": "^4.0.0",
@@ -59,14 +61,18 @@
   "babel": {
     "presets": [
       "@babel/preset-env",
-      "@babel/preset-react"
+      "@babel/preset-react",
+      "@babel/preset-typescript",
+      "@babel/preset-react-native"
     ]
   },
   "env": {
     "test": {
       "presets": [
         "@babel/preset-env",
-        "@babel/preset-react"
+        "@babel/preset-react",
+        "@babel/preset-typescript",
+        "@babel/preset-react-native"
       ]
     }
   },


### PR DESCRIPTION
Add Babel and Jest configuration to support modern JavaScript, React, TypeScript, and React Native.

* **package.json**
  - Add `@babel/preset-typescript` and `@babel/preset-react-native` to `devDependencies`.
  - Add `@babel/preset-typescript` and `@babel/preset-react-native` to `babel.presets`.

* **babel.config.js**
  - Create a new file to configure Babel presets and plugins.
  - Add `@babel/preset-env`, `@babel/preset-react`, `@babel/preset-typescript`, and `@babel/preset-react-native` to the `presets` array.

* **jest.config.js**
  - Create a new file to configure Jest.
  - Add `transform` property to use `babel-jest` for JavaScript and TypeScript files.
  - Add `transformIgnorePatterns` property to include `node_modules` folder.
  - Add `moduleNameMapper` property to mock non-JS modules.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shnz99/book-tracking-app/pull/16?shareId=e9bf2aed-1b92-4355-8164-3e8439b08bd4).